### PR TITLE
Add what item was dropped to notify message.

### DIFF
--- a/src/me/camdenorrb/droppatch/DropPatch.java
+++ b/src/me/camdenorrb/droppatch/DropPatch.java
@@ -21,7 +21,7 @@ public class DropPatch extends JavaPlugin implements Listener {
         saveDefaultConfig();
         getServer().getPluginManager().registerEvents(this, this);
         notify = getConfig().getBoolean("SendNotification", true);
-        notifyMsg = ChatUtils.format(getConfig().getString("NotifyMsg", "&c&l$player, has been caught trying to Drop Glitch!"));
+        notifyMsg = ChatUtils.format(getConfig().getString("NotifyMsg", "&c&l$player, has been caught trying to Drop Glitch! They tried to duplicate $item."));
     }
 
     @EventHandler(ignoreCancelled = true, priority = EventPriority.HIGHEST)
@@ -33,7 +33,7 @@ public class DropPatch extends JavaPlugin implements Listener {
 
         if (!notify) return;
 
-        String replacedMsg = notifyMsg.replace("$player", player.getName());
-        getServer().getOnlinePlayers().stream().filter(player1 -> !player1.hasPermission("DropPatch.Notify")).forEach(player1 -> player1.sendMessage(replacedMsg));
+		final String replacedMsg = notifyMsg.replace("$player", player.getName()).replace("$item", event.getItemDrop().getType().toString().toLowerCase());
+		Bukkit.getServer().getOnlinePlayers().stream().filter(player1 -> !player1.hasPermission("DropPatch.Notify")).forEach(player1 -> player1.sendMessage(replacedMsg));
     }
 }


### PR DESCRIPTION
The placeholder $item was added to the NotifyMsg, and it is replaced with the type name of the item that was dropped.
Also the string replacedMsg in onDrop was changed to final (I dont know why it is needed, but my IDE required it).